### PR TITLE
FocusRecipeView visar det specifika receptet

### DIFF
--- a/lib/FakeRecipeList.dart
+++ b/lib/FakeRecipeList.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:projectapp/FocusRecipeView.dart';
 import 'package:projectapp/model.dart';
 
 class FakeRecipeList extends StatefulWidget {
@@ -21,7 +22,10 @@ class _FakeRecipeListState extends State<FakeRecipeList> {
     return ListTile(
       title: Text(item.title),
       trailing: Text(item.cooklength),
-      onTap: () {},
+      onTap: () {
+        Navigator.push(context,
+            MaterialPageRoute(builder: (context) => FocusRecipeView(item)));
+      },
     );
   }
 }

--- a/lib/FocusRecipeView.dart
+++ b/lib/FocusRecipeView.dart
@@ -13,34 +13,24 @@ class FocusRecipeView extends StatelessWidget {
           onPressed: () => Navigator.of(context).pop(),
         ),
         backgroundColor: Colors.greenAccent[100],
-        title: Text('*Det valda receptet*',
+        title: Text('Receptet för ' + item.title,
             style: TextStyle(
                 color: Colors.black,
                 fontSize: 20,
                 fontWeight: FontWeight.bold)),
-        actions: [
-          Container(
-            margin: EdgeInsets.all(15),
-            child: Icon(
-              Icons.star,
-              color: Colors.yellow[700],
-              size: 30,
-            ),
-          )
-        ],
       ),
       body: Column(
         children: [
           _picture(),
           Text(
-            'En mystisk gryta',
+            item.title,
             style: TextStyle(
                 fontSize: 20, color: Colors.black, fontStyle: FontStyle.italic),
           ),
-          Text('Ingridenser, kanske vatten är bra att ha'),
-          Text('Instruktioner - Gör så här blablabla'),
-          IconButton(icon: Icon(Icons.thumb_up), onPressed: () {}),
-          IconButton(icon: Icon(Icons.thumb_down), onPressed: () {}),
+          Text(
+            item.ingredients,
+            style: TextStyle(fontSize: 18),
+          ),
         ],
       ),
     );

--- a/lib/Model.dart
+++ b/lib/Model.dart
@@ -2,27 +2,29 @@ import 'package:flutter/material.dart';
 
 class RecipeItem {
   String title;
+  String ingredients;
   String cooklength;
-  bool star;
 
-  RecipeItem({this.title, this.cooklength, this.star});
+  RecipeItem({this.title, this.ingredients, this.cooklength});
 }
 
 class MyState extends ChangeNotifier {
   List<RecipeItem> _list = [
-    RecipeItem(title: 'Lasagne', cooklength: '2h', star: false),
-    RecipeItem(title: 'Tomtegröt', cooklength: '30m', star: false),
-    RecipeItem(title: 'Chili Con carne', cooklength: '1h', star: false),
-    RecipeItem(title: 'Pasta Alfredo', cooklength: '45m', star: false),
-    RecipeItem(title: 'Ugnspannkaka', cooklength: '50m', star: false),
-    RecipeItem(title: 'Franssyska i ugn', cooklength: '2h', star: false),
-    RecipeItem(title: 'Ärtsoppa', cooklength: '30m', star: false),
-    RecipeItem(title: 'Pytt i panna', cooklength: '10m', star: false),
-    RecipeItem(title: 'Chorizogryta', cooklength: '45m', star: false),
-    RecipeItem(title: 'Igelkottsgryta', cooklength: '1h', star: false),
-    RecipeItem(title: 'Rokot krompli', cooklength: '1,5h', star: false),
-    RecipeItem(title: 'Tikka massala', cooklength: '50m', star: false),
-    RecipeItem(title: 'Pasta Bolognese', cooklength: '30m', star: false),
+    RecipeItem(title: 'Lasagne', ingredients: 'test', cooklength: '2h'),
+    RecipeItem(title: 'Tomtegröt', ingredients: 'test', cooklength: '30m'),
+    RecipeItem(title: 'Chili Con carne', ingredients: 'test', cooklength: '1h'),
+    RecipeItem(title: 'Pasta Alfredo', ingredients: 'test', cooklength: '45m'),
+    RecipeItem(title: 'Ugnspannkaka', ingredients: 'test', cooklength: '50m'),
+    RecipeItem(
+        title: 'Franssyska i ugn', ingredients: 'test', cooklength: '2h'),
+    RecipeItem(title: 'Ärtsoppa', ingredients: 'test', cooklength: '30m'),
+    RecipeItem(title: 'Pytt i panna', ingredients: 'test', cooklength: '10m'),
+    RecipeItem(title: 'Chorizogryta', ingredients: 'test', cooklength: '45m'),
+    RecipeItem(title: 'Igelkottsgryta', ingredients: 'test', cooklength: '1h'),
+    RecipeItem(title: 'Rokot krompli', ingredients: 'test', cooklength: '1,5h'),
+    RecipeItem(title: 'Tikka massala', ingredients: 'test', cooklength: '50m'),
+    RecipeItem(
+        title: 'Pasta Bolognese', ingredients: 'test', cooklength: '30m'),
   ];
 
   List<RecipeItem> get list => _list;


### PR DESCRIPTION
Det som gjordes:
1. Tog bort lite saker med star/favorite
2. La till så focusvyn bara visar upp det receptet man tryckte på. 
3. La till kod för ingredients, så varje recept ska ha sin egna ingridiens. I nu läget är recepten fyllda med 'test', som ingredients.
4. Samma sak skulle göras med resten av attributen som api:en tar emot/ genererar. Men i och med att  vi inte har bestämt oss för vilka sådana attribut vi vill ha med så valde jag att bara inkludera title, ingredients och koktid.
